### PR TITLE
Use /usr/bin/env to execute bash in shebang

### DIFF
--- a/gitdot
+++ b/gitdot
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 shopt -s extglob


### PR DESCRIPTION
For those poor souls who have an ancient version of Bash in /bin.

(This mostly happens to macOS users.)
