### PR TITLE
genreadme: provide a generic "$HOME" for README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,15 +4,16 @@ Usage: gitdot [-h] [-d GIT_DIR] [-w GIT_WORK_TREE] <command> [args...]
 Manage a bare git repository for tracking hidden ("dot") files in a
 working tree that exists at an unrelated path.
 
-    GIT_DIR         path to bare git repository (default: /home/malsyned/.dotfiles.git)
-    GIT_WORK_TREE   path to working directory (default: /home/malsyned)
+    GIT_DIR         path to bare git repository (default: $HOME/.dotfiles.git)
+    GIT_WORK_TREE   path to working directory (default: $HOME)
 
 command is one of:
     init        create the git repository
     destroy     delete the git repository
     clone       clone an existing repository
     dstatus     display status of all hidden files
-    bindump     create text versions of binary files as configured in ~/.config/gitdot/bindump.conf
+    bindump     create text versions of binary files as configured in
+                $HOME/.config/gitdot/bindump.conf
 
 Any other command and arguments are passed unmodified to git with the
 working directory and git directory configured appropriately for

--- a/docs/genreadme.sh
+++ b/docs/genreadme.sh
@@ -1,3 +1,4 @@
+export HOME='$HOME'
 (
     echo '```'
     ./gitdot help

--- a/gitdot
+++ b/gitdot
@@ -32,7 +32,8 @@ command is one of:
     destroy     delete the git repository
     clone       clone an existing repository
     dstatus     display status of all hidden files
-    bindump     create text versions of binary files as configured in ~/.config/gitdot/bindump.conf
+    bindump     create text versions of binary files as configured in
+                ${HOME}/.config/gitdot/bindump.conf
 
 Any other command and arguments are passed unmodified to git with the
 working directory and git directory configured appropriately for


### PR DESCRIPTION
It's not ideal to have the path to the homedir of whomstever ran
`docs/genreadme.sh` memorialized in `docs/README.md` for all time.
