### PR TITLE
Add `gitdot shell [subshell args...]` command

### DIFF
--- a/gitdot
+++ b/gitdot
@@ -88,6 +88,18 @@ Clone a git repository into the bare repository GIT_DIR
 EOF
 }
 
+gitdot-shell () {
+    "$SHELL" "$@"
+}
+
+gitdot-help-shell () {
+    cat <<EOF
+${prog} shell [args to subshell...]
+
+Spawn a subshell with GIT_DIR and GIT_WORK_TREE set
+EOF
+}
+
 gitdot-dstatus() {
     git status "$@" .!(.|)
 }


### PR DESCRIPTION
If you're going to be doing some messing around in your dotfiles repo,
it might be convenient to not have to write `gitdot` every time.

Idk, this is probably a footgun.
