### PR TITLE
configure-repo: ensure ${GIT_DIR}/info dir exists

### DIFF
--- a/gitdot
+++ b/gitdot
@@ -42,6 +42,7 @@ EOF
 }
 
 configure-repo () {
+    mkdir -p "${GIT_DIR}/info"
     cat > "${GIT_DIR}/info/exclude" <<EOF
 $(realpath --relative-to "${GIT_WORK_TREE}" "${GIT_DIR}")
 EOF


### PR DESCRIPTION
I forget when exactly I ran into this, but at some point configure-repo
was failing when it tried to write `exclude` into `${GIT_DIR}/info`.
Creating that directory first fixed it.
