### PR TITLE
clone: always clone into $GIT_DIR

### DIFF
--- a/gitdot
+++ b/gitdot
@@ -79,7 +79,7 @@ EOF
 }
 
 gitdot-clone () {
-    git clone --bare --no-checkout "$@"
+    git clone --bare --no-checkout "$@" "$GIT_DIR"
     configure-repo
 }
 


### PR DESCRIPTION
This is one possible solution to issue #8. I'm not thrilled with it, but nor am I thrilled with the concept of parsing the arguments that the user passed in to see if they specified a target directory.

(What would be *nice* is if git-clone(1) would use `$GIT_DIR` and/or `$GIT_WORK_TREE` as defaults when cloning, but I imagine there are adequate reasons for them not to.)
